### PR TITLE
Step input improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-pbr >= 0.10
+asteval >= 0.9
 boto >= 2.38
 enum34 >= 1.0
-yunomi >= 0.3
+Jinja2 >= 2.7.3
+jsonschema >= 2.4
 PyYAML >= 3.0
 YAQL >= 0.2, < 0.3
-Jinja2 >= 2.7.3
-Sphinx >= 1.3.1
-asteval >= 0.9
+yunomi >= 0.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,4 @@
-testrepository >= 0.0.18
 mock >= 1.0
+pbr >= 0.10
+testrepository >= 0.0.18
+Sphinx >= 1.3

--- a/tests/plan_hello.yml
+++ b/tests/plan_hello.yml
@@ -15,5 +15,6 @@ steps:
 activities:
 - name: "HelloWorld"      # Activity name in SWF
   version: "1.0"
-  input_spec: ""
+  input_spec:
+    type: "null"
   outputs_spec: ~

--- a/tests/state_machine_test.py
+++ b/tests/state_machine_test.py
@@ -23,7 +23,7 @@ import ct.workspace
 import ct.state_machine
 
 
-class DeciderTest(unittest.TestCase):
+class StateMachineTest(unittest.TestCase):
     MY_DIR = os.path.realpath(os.path.dirname(__file__))
 
     def setUp(self):

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -1,0 +1,80 @@
+"""Unit tests for ct.state_machine
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.append(
+    os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..'
+        )
+    )
+)
+
+import collections
+import mock
+import yaml
+
+import ct
+import ct.state
+
+
+TestParent = collections.namedtuple('TestParent', ['name', 'output'])
+
+
+class StepStateTest(unittest.TestCase):
+    def setUp(self):
+        self.mock_step = mock.Mock()
+        self.step_state = ct.state.StepState(step=self.mock_step,
+                                             status='running',
+                                             context='__test__')
+
+    def test_step_prepare_no_parents(self):
+        """No parents, `step.prepare` called with an empty dict."""
+        self.step_state.update('ready', '__test_update__')
+        self.mock_step.prepare.assert_called_with({})
+
+    def test_step_prepare_parents(self):
+        """Make sure `step.prepare` is called with a dict of all the parents
+        attributes.
+        """
+        self.step_state.parents = [
+            TestParent('foo', {'a': 1}),
+            TestParent('bar', {'b': 1}),
+            TestParent('baz', {'c': 1}),
+        ]
+        self.step_state.update('ready', '__test_update__')
+        self.mock_step.prepare.assert_called_with(
+            {
+                'foo': {'a': 1},
+                'bar': {'b': 1},
+                'baz': {'c': 1},
+            }
+        )
+
+    def test_step_prepare_parents_with_input(self):
+        """Make sure `step.prepare` is called with a dict of all the parents
+        attributes and that the special input step in properly named.
+        """
+        self.step_state.parents = [
+            TestParent('foo', {'a': 1}),
+            TestParent(ct.state.INIT_STEP, {'b': 1}),
+            TestParent('baz', {'c': 1}),
+        ]
+        self.step_state.update('ready', '__test_update__')
+        self.mock_step.prepare.assert_called_with(
+            {
+                'foo': {'a': 1},
+                '__input__': {'b': 1},
+                'baz': {'c': 1},
+            }
+        )
+
+
+if __name__ == '__main__':
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
- Implement JSONSchema Draft v4 for Activities
  input.
- Rename the workflow's input to `__input__`.
- Verify that all parent steps used in the input
  template are declared as required.
- Add step input preparation test
