### PR TITLE
state: Fix global state change

### DIFF
--- a/pydecider/state.py
+++ b/pydecider/state.py
@@ -125,7 +125,7 @@ class State(object):
                           new_output=new_data)
 
         if self._end_step.status is StepStateStatus.ready:
-            self.status = StateStatus.completed
+            self.status = StateStatus.suceeded
         elif self._end_step.status is StepStateStatus.aborted:
             self.status = StateStatus.failed
 


### PR DESCRIPTION
Fix state $end status value to "succeeded" so that the decider set the SWF
Workflow as completed.
